### PR TITLE
Kakao Oauth Token

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,11 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="org.retriever.dailypet">
-    <!-- 인터넷 사용 권한 설정 -->
     <uses-permission android:name="android.permission.INTERNET" /> <!-- 인터넷 사용권한 -->
     <uses-permission android:name="android.permission.CAMERA" /> <!-- 카메라 사용권한 -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" /> <!-- 저장소 읽기 권한 -->
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /> <!-- 저장소 쓰기 권한 -->
 
     <application
         android:name=".GlobalApplication"
@@ -15,7 +14,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/dailypet_logo"
         android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
+        android:roundIcon="@mipmap/dailypet_logo_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.DailyPet"
         tools:targetApi="31">
@@ -40,8 +39,20 @@
             android:theme="@style/Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <!-- Redirect URI: "kakao${NATIVE_APP_KEY}://oauth" -->
+                <data android:host="oauth"
+                    android:scheme="@string/manifest_kakao_native_app_key" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/org/retriever/dailypet/LoginActivity.kt
+++ b/app/src/main/java/org/retriever/dailypet/LoginActivity.kt
@@ -31,7 +31,6 @@ class LoginActivity : AppCompatActivity() {
         var view = binding.root
         setContentView(view)
 
-
         binding.btnKakaoLogin.setOnClickListener {
             if (AuthApiClient.instance.hasToken()) {
                 UserApiClient.instance.accessTokenInfo { _, error ->
@@ -70,6 +69,18 @@ class LoginActivity : AppCompatActivity() {
         binding.btnNaverLogin.setOnClickListener{
             val nextIntent = Intent(this, RegisterProfileActivity::class.java)
             startActivity(nextIntent)
+        }
+
+        binding.btnLogout.setOnClickListener{
+            // 카카오 로그아웃
+            UserApiClient.instance.logout { error ->
+                if (error != null) {
+                    Log.e(TAG, "로그아웃 실패. SDK에서 토큰 삭제됨", error)
+                }
+                else {
+                    Log.d(TAG, "로그아웃 성공. SDK에서 토큰 삭제됨")
+                }
+            }
         }
     }
 

--- a/app/src/main/java/org/retriever/dailypet/LoginActivity.kt
+++ b/app/src/main/java/org/retriever/dailypet/LoginActivity.kt
@@ -6,9 +6,11 @@ import android.os.Bundle
 import android.util.Log
 import android.widget.ImageButton
 import androidx.lifecycle.lifecycleScope
+import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.KakaoSdk
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
+import com.kakao.sdk.common.util.Utility
 import com.kakao.sdk.user.UserApiClient
 import kotlinx.coroutines.launch
 
@@ -23,17 +25,18 @@ class LoginActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
-
+        val keyHash = Utility.getKeyHash(this)
+        Log.e("Key ",keyHash)
         val context = this
         val kakaoLoginButton = findViewById<ImageButton>(R.id.btn_kakaoLogin)
         var naverLoginButton = findViewById<ImageButton>(R.id.btn_naverLogin)
 
         kakaoLoginButton.setOnClickListener {
+            lateinit var token : OAuthToken
             lifecycleScope.launch {
                 try {
-                    // 서비스 코드에서는 간단하게 로그인 요청하고 oAuthToken 을 받아올 수 있다.
-                    val oAuthToken = UserApiClient.loginWithKakao(context)
-                    Log.d("LoginActivity", "Token:  > $oAuthToken")
+                    token = UserApiClient.loginWithKakao(context)
+                    Log.e("LoginActivity", "Token:  > $token")
                 } catch (error: Throwable) {
                     if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
                         Log.d("LoginActivity", "사용자가 명시적으로 취소")
@@ -41,6 +44,10 @@ class LoginActivity : AppCompatActivity() {
                         Log.e("LoginActivity", "인증 에러 발생", error)
                     }
                 }
+            }
+            if(token != null) {
+                val nextIntent = Intent(this, RegisterProfileActivity::class.java)
+                startActivity(nextIntent)
             }
         }
         naverLoginButton.setOnClickListener{

--- a/app/src/main/java/org/retriever/dailypet/LoginActivity.kt
+++ b/app/src/main/java/org/retriever/dailypet/LoginActivity.kt
@@ -4,15 +4,13 @@ import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
-import android.widget.ImageButton
 import androidx.lifecycle.lifecycleScope
-import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.KakaoSdk
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
-import com.kakao.sdk.common.util.Utility
 import com.kakao.sdk.user.UserApiClient
 import kotlinx.coroutines.launch
+import org.retriever.dailypet.databinding.ActivityLoginBinding
 
 class GlobalApplication : Application() {
     override fun onCreate() {
@@ -22,21 +20,25 @@ class GlobalApplication : Application() {
 }
 
 class LoginActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityLoginBinding
+    private var TAG = "LOGIN"
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_login)
-        val keyHash = Utility.getKeyHash(this)
-        Log.e("Key ",keyHash)
+        binding = ActivityLoginBinding.inflate(layoutInflater)
+        var view = binding.root
+        setContentView(view)
         val context = this
-        val kakaoLoginButton = findViewById<ImageButton>(R.id.btn_kakaoLogin)
-        var naverLoginButton = findViewById<ImageButton>(R.id.btn_naverLogin)
 
-        kakaoLoginButton.setOnClickListener {
-            lateinit var token : OAuthToken
+        binding.btnKakaoLogin.setOnClickListener {
+            var kakaoLogin : Boolean = false
             lifecycleScope.launch {
                 try {
-                    token = UserApiClient.loginWithKakao(context)
-                    Log.e("LoginActivity", "Token:  > $token")
+                    var token = UserApiClient.loginWithKakao(context)
+                    Log.d(TAG, "Token:  > $token")
+                    Intent(this@LoginActivity, RegisterProfileActivity::class.java).also{
+                        startActivity(it)
+                        finish()
+                    }
                 } catch (error: Throwable) {
                     if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
                         Log.d("LoginActivity", "사용자가 명시적으로 취소")
@@ -45,12 +47,8 @@ class LoginActivity : AppCompatActivity() {
                     }
                 }
             }
-            if(token != null) {
-                val nextIntent = Intent(this, RegisterProfileActivity::class.java)
-                startActivity(nextIntent)
-            }
         }
-        naverLoginButton.setOnClickListener{
+        binding.btnNaverLogin.setOnClickListener{
             val nextIntent = Intent(this, RegisterProfileActivity::class.java)
             startActivity(nextIntent)
         }

--- a/app/src/main/java/org/retriever/dailypet/LoginActivity.kt
+++ b/app/src/main/java/org/retriever/dailypet/LoginActivity.kt
@@ -5,9 +5,11 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 import androidx.lifecycle.lifecycleScope
+import com.kakao.sdk.auth.AuthApiClient
 import com.kakao.sdk.common.KakaoSdk
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
+import com.kakao.sdk.common.model.KakaoSdkError
 import com.kakao.sdk.user.UserApiClient
 import kotlinx.coroutines.launch
 import org.retriever.dailypet.databinding.ActivityLoginBinding
@@ -22,35 +24,71 @@ class GlobalApplication : Application() {
 class LoginActivity : AppCompatActivity() {
     private lateinit var binding: ActivityLoginBinding
     private var TAG = "LOGIN"
+    private var context = this
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityLoginBinding.inflate(layoutInflater)
         var view = binding.root
         setContentView(view)
-        val context = this
+
 
         binding.btnKakaoLogin.setOnClickListener {
-            var kakaoLogin : Boolean = false
-            lifecycleScope.launch {
-                try {
-                    var token = UserApiClient.loginWithKakao(context)
-                    Log.d(TAG, "Token:  > $token")
-                    Intent(this@LoginActivity, RegisterProfileActivity::class.java).also{
-                        startActivity(it)
-                        finish()
+            if (AuthApiClient.instance.hasToken()) {
+                UserApiClient.instance.accessTokenInfo { _, error ->
+                    if (error != null) {
+                        if (error is KakaoSdkError && error.isInvalidTokenError() == true) {
+                            //로그인 필요
+                            kakaoLogin()
+                        }
+                        else {
+                            //기타 에러
+                        }
                     }
-                } catch (error: Throwable) {
-                    if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
-                        Log.d("LoginActivity", "사용자가 명시적으로 취소")
-                    } else {
-                        Log.e("LoginActivity", "인증 에러 발생", error)
+                    else {
+                        //토큰 유효성 체크 성공(필요 시 토큰 갱신됨)
+                        UserApiClient.instance.accessTokenInfo { tokenInfo, error ->
+                            if (error != null) {
+                                Log.e(TAG, "토큰 정보 보기 실패", error)
+                            }
+                            else if (tokenInfo != null) {
+                                Log.i(TAG, "토큰 정보 보기 성공" +
+                                        "\n회원번호: ${tokenInfo.id}" +
+                                        "\n만료시간: ${tokenInfo.expiresIn} 초")
+                            }
+                        }
+                        val nextIntent = Intent(this, RegisterProfileActivity::class.java)
+                        startActivity(nextIntent)
                     }
                 }
             }
+            else {
+                //로그인 필요
+                kakaoLogin()
+            }
+
         }
         binding.btnNaverLogin.setOnClickListener{
             val nextIntent = Intent(this, RegisterProfileActivity::class.java)
             startActivity(nextIntent)
+        }
+    }
+
+    private fun kakaoLogin(){
+        lifecycleScope.launch {
+            try {
+                var token = UserApiClient.loginWithKakao(context)
+                Log.d(TAG, "Token:  > $token")
+                Intent(this@LoginActivity, RegisterProfileActivity::class.java).also{
+                    startActivity(it)
+                    finish()
+                }
+            } catch (error: Throwable) {
+                if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
+                    Log.d("LoginActivity", "사용자가 명시적으로 취소")
+                } else {
+                    Log.e("LoginActivity", "인증 에러 발생", error)
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/org/retriever/dailypet/RegisterProfileActivity.kt
+++ b/app/src/main/java/org/retriever/dailypet/RegisterProfileActivity.kt
@@ -50,6 +50,8 @@ class RegisterProfileActivity : AppCompatActivity() {
                         "\n회원번호: ${user.id}" +
                         "\n이메일: ${user.kakaoAccount?.email}" +
                         "\n닉네임: ${user.kakaoAccount?.profile?.nickname}")
+                binding.textRegisterProfileName.text = user.kakaoAccount?.profile?.nickname
+                binding.textRegisterProfileEmail.text = user.kakaoAccount?.email
             }
         }
 

--- a/app/src/main/java/org/retriever/dailypet/RegisterProfileActivity.kt
+++ b/app/src/main/java/org/retriever/dailypet/RegisterProfileActivity.kt
@@ -18,6 +18,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import com.kakao.sdk.user.UserApiClient
 import org.retriever.dailypet.databinding.ActivityMainBinding
 import org.retriever.dailypet.databinding.ActivityRegisterProfileBinding
 
@@ -39,6 +40,18 @@ class RegisterProfileActivity : AppCompatActivity() {
         binding = ActivityRegisterProfileBinding.inflate(layoutInflater)
         var view = binding.root
         setContentView(view)
+
+        UserApiClient.instance.me { user, error ->
+            if (error != null) {
+                Log.e(TAG, "사용자 정보 요청 실패", error)
+            }
+            else if (user != null) {
+                Log.d(TAG, "사용자 정보 요청 성공" +
+                        "\n회원번호: ${user.id}" +
+                        "\n이메일: ${user.kakaoAccount?.email}" +
+                        "\n닉네임: ${user.kakaoAccount?.profile?.nickname}")
+            }
+        }
 
         /* Camera Register */
         resultLauncher = registerForActivityResult(

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -61,4 +61,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <Button
+        android:id="@+id/btn_logout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="24dp"
+        android:text="로그아웃"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/kakao_strings.xml
+++ b/app/src/main/res/values/kakao_strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kakao_native_app_key">45276ed14e089e697b39bb9cab043b7f</string>
+    <string name="manifest_kakao_native_app_key">kakao45276ed14e089e697b39bb9cab043b7f</string>
 </resources>


### PR DESCRIPTION
## PR Description
- 관련 이슈 : 카카오 토큰 API
- JIRA 백로그 : PET-168
- 관련 문서 : N/A
## Changes
- 카카오 인가 코드 작성 (native app key)
- 토큰 보유 여부 체크
- 로그인 성공시 다음 화면 (서버 응답에 따라)
- 프로필 등록화면에서 카카오 정보 로드 테스트
## Screenshots
<img src="https://user-images.githubusercontent.com/75887645/182034673-5c7f7bcb-7462-4b21-a349-f628725b3a5d.png" width="250" height="500"/><img src="https://user-images.githubusercontent.com/75887645/182034694-2589e2a9-59f1-48d1-8acf-8841b0fc385e.png" width="250" height="500"/>


## To Server
- 클라이언트에서 access 토큰 전달 시 로그인 회원의 회원 등록 여부를 전달해주시면 됩니다
